### PR TITLE
Unique names in az lambda resources and fix deploy script

### DIFF
--- a/resources/common/format_func.go
+++ b/resources/common/format_func.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"regexp"
+	"strings"
+)
+
+type FormatFunc func(s string) string
+
+func LowercaseAlphanumericFormatFunc(s string) string {
+	reg, err := regexp.Compile("[^a-z\\d]+")
+	if err != nil {
+		panic(err)
+	}
+	return reg.ReplaceAllString(strings.ToLower(s), "")
+}
+
+func AlphanumericFormatFunc(s string) string {
+	reg, err := regexp.Compile("[^a-zA-Z\\d]+")
+	if err != nil {
+		panic(err)
+	}
+	return reg.ReplaceAllString(s, "")
+}

--- a/resources/common/helper.go
+++ b/resources/common/helper.go
@@ -1,8 +1,10 @@
 package common
 
 import (
+	"hash/fnv"
 	"log"
 	"math/rand"
+	"multy-go/validate"
 	"regexp"
 )
 
@@ -32,4 +34,43 @@ func RandomString(n int) string {
 		s[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(s)
+}
+
+// UniqueId generates a stable string composed of prefix+suffix and a 4 char hash.
+// Prefix can be any size but will be sliced if bigger than 16 chars. Suffix can have 4 chars at most.
+// Returns a string with at most 24 chars.
+func UniqueId(prefix string, suffix string, formatFunc FormatFunc) string {
+	if len(suffix) > 4 {
+		validate.LogInternalError("suffix must be shorter than 4 chars")
+	}
+	result := ""
+	formattedPrefix := formatFunc(prefix)
+	if len(formattedPrefix) > 16 {
+		result += formattedPrefix[:12] + generateHash(prefix)
+	} else {
+		result += formattedPrefix
+	}
+
+	result += suffix
+	result += generateHash(prefix + suffix)
+
+	return result
+}
+
+func generateHash(s string) string {
+	result := ""
+	h := fnv.New32a()
+	_, err := h.Write([]byte(s))
+	if err != nil {
+		panic(err)
+	}
+
+	hashSum := h.Sum32()
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz123456789")
+
+	for i := 0; i < 4; i++ {
+		idx := int(hashSum >> (i * 8) & 0xFF)
+		result += string(letters[idx%len(letters)])
+	}
+	return result
 }

--- a/resources/output/local_exec/local_exec.go
+++ b/resources/output/local_exec/local_exec.go
@@ -2,7 +2,7 @@ package local_exec
 
 type LocalExec struct {
 	Label      string `hcl:",key"`
-	WorkingDir string `hcl:"working_dir"`
+	WorkingDir string `hcl:"working_dir" hcle:"omitempty"`
 	Command    string `hcl:"command"`
 }
 

--- a/test/lambda/lambda/main.hcl
+++ b/test/lambda/lambda/main.hcl
@@ -1,5 +1,5 @@
-multy "lambda" "test" {
-  function_name = "test_name"
+multy "lambda" "super_long_function" {
+  function_name = "super_long_function"
   runtime = "python3.9"
   source_code_dir = cloud_specific_value({aws: "source_dir/aws", azure: "source_dir/azure"})
 }

--- a/test/lambda/lambda/main.tf
+++ b/test/lambda/lambda/main.tf
@@ -1,41 +1,61 @@
-resource "aws_lambda_function" "test_aws" {
-  tags = {
-    Name = "test_name"
+data "archive_file" "super_long_function_aws" {
+  type        = "zip"
+  source_dir  = "source_dir/aws"
+  output_path = ".multy/tmp/super_long_function_aws.zip"
+}
+resource "aws_lambda_function" "super_long_function_aws" {
+  tags =  {
+    Name = "super_long_function"
   }
-  function_name    = "test_name"
-  filename         = ".multy/tmp/test_name.zip"
-  source_code_hash = data.archive_file.test_aws.output_base64sha256
-  role             = aws_iam_role.iam_for_lambda_test_name.arn
+
+  function_name    = "super_long_function"
+  role             = aws_iam_role.iam_for_lambda_super_long_function.arn
+  filename         = ".multy/tmp/super_long_function_aws.zip"
+  source_code_hash = data.archive_file.super_long_function_aws.output_base64sha256
   runtime          = "python3.9"
   handler          = "lambda_function.lambda_handler"
 }
-resource "aws_iam_role" "iam_for_lambda_test_name" {
-  tags = {
-    Name = "iam_for_lambda_test_name"
+resource "aws_iam_role" "iam_for_lambda_super_long_function" {
+  tags =  {
+    Name = "iam_for_lambda_super_long_function"
   }
-  name               = "iam_for_lambda_test_name"
+
+  name               = "iam_for_lambda_super_long_function"
   assume_role_policy = "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Action\": \"sts:AssumeRole\",\"Principal\": {\"Service\": \"lambda.amazonaws.com\"},\"Effect\": \"Allow\",\"Sid\": \"\"}]}"
-}
-data "archive_file" "test_aws" {
-  type        = "zip"
-  source_dir  = "source_dir/aws"
-  output_path = ".multy/tmp/test_name.zip"
 }
 resource "azurerm_resource_group" "fun-rg" {
   name     = "fun-rg"
   location = "northeurope"
 }
-resource "azurerm_storage_account" "test" {
+data "archive_file" "super_long_function_azure" {
+  type        = "zip"
+  source_dir  = "source_dir/azure"
+  output_path = ".multy/tmp/super_long_function_azure.zip"
+}
+resource "azurerm_storage_account" "super_long_function_azure" {
   resource_group_name      = azurerm_resource_group.fun-rg.name
-  name                     = "teststacct"
+  name                     = "superlongfunit2xstaciiav"
   location                 = "northeurope"
   account_tier             = "Standard"
   account_replication_type = "LRS"
   allow_blob_public_access = false
 }
-resource "azurerm_app_service_plan" "test" {
+resource "azurerm_function_app" "super_long_function_azure" {
+  resource_group_name        = azurerm_resource_group.fun-rg.name
+  name                       = "superlongfunction"
+  location                   = "northeurope"
+  storage_account_name       = azurerm_storage_account.super_long_function_azure.name
+  storage_account_access_key = azurerm_storage_account.super_long_function_azure.primary_access_key
+  app_service_plan_id        = azurerm_app_service_plan.super_long_function_azure.id
+  os_type                    = "linux"
+
+  provisioner "local-exec" {
+    command     = "az functionapp deployment source config-zip -g ${self.resource_group_name} -n ${self.name} --src ${data.archive_file.super_long_function_azure.output_path}"
+  }
+}
+resource "azurerm_app_service_plan" "super_long_function_azure" {
   resource_group_name = azurerm_resource_group.fun-rg.name
-  name                = "testservplan"
+  name                = "superlongfunit2xsvpl15kn"
   location            = "northeurope"
   kind                = "Linux"
   reserved            = true
@@ -43,19 +63,6 @@ resource "azurerm_app_service_plan" "test" {
   sku {
     tier = "Dynamic"
     size = "Y1"
-  }
-}
-resource "azurerm_function_app" "test" {
-  resource_group_name        = azurerm_resource_group.fun-rg.name
-  name                       = "testname"
-  location                   = "northeurope"
-  storage_account_name       = azurerm_storage_account.test.name
-  storage_account_access_key = azurerm_storage_account.test.primary_access_key
-  app_service_plan_id        = azurerm_app_service_plan.test.id
-  os_type                    = "linux"
-  provisioner "local-exec" {
-    working_dir = "source_dir/azure"
-    command = "func azure functionapp publish ${self.id}"
   }
 }
 provider "aws" {

--- a/test/lambda/lambda_source_code_obj/main.tf
+++ b/test/lambda/lambda_source_code_obj/main.tf
@@ -14,18 +14,18 @@ resource "aws_lambda_function" "test_aws" {
   }
 
   function_name = "test_name"
-  role          = aws_iam_role.iam_for_lambda_test_name.arn
+  role          = aws_iam_role.iam_for_lambda_test.arn
   runtime       = "python3.9"
   handler       = "lambda_function.lambda_handler"
   s3_bucket     = aws_s3_bucket.obj_storage_aws.id
   s3_key        = aws_s3_bucket_object.source_code_aws.key
 }
-resource "aws_iam_role" "iam_for_lambda_test_name" {
+resource "aws_iam_role" "iam_for_lambda_test" {
   tags =  {
-    Name = "iam_for_lambda_test_name"
+    Name = "iam_for_lambda_test"
   }
 
-  name               = "iam_for_lambda_test_name"
+  name               = "iam_for_lambda_test"
   assume_role_policy = "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Action\": \"sts:AssumeRole\",\"Principal\": {\"Service\": \"lambda.amazonaws.com\"},\"Effect\": \"Allow\",\"Sid\": \"\"}]}"
 }
 resource "azurerm_resource_group" "fun-rg" {
@@ -62,18 +62,18 @@ resource "azurerm_resource_group" "st-rg" {
   name     = "st-rg"
   location = "northeurope"
 }
-resource "azurerm_function_app" "test" {
+resource "azurerm_function_app" "test_azure" {
   resource_group_name        = azurerm_resource_group.fun-rg.name
   name                       = "testname"
   location                   = "northeurope"
   storage_account_name       = azurerm_storage_account.obj_storage_azure.name
   storage_account_access_key = azurerm_storage_account.obj_storage_azure.primary_access_key
-  app_service_plan_id        = azurerm_app_service_plan.test.id
+  app_service_plan_id        = azurerm_app_service_plan.test_azure.id
   os_type                    = "linux"
 }
-resource "azurerm_app_service_plan" "test" {
+resource "azurerm_app_service_plan" "test_azure" {
   resource_group_name = azurerm_resource_group.fun-rg.name
-  name                = "testservplan"
+  name                = "testnamesvplnlce"
   location            = "northeurope"
   kind                = "Linux"
   reserved            = true


### PR DESCRIPTION
unique names for az storage accounts and service plans in lambdas

deployment script uses az client instead to remove outside dependencies
