### PR TITLE
fix: wait a few minutes for policy access to take effect in vault test

### DIFF
--- a/resources/types/virtual_machine.go
+++ b/resources/types/virtual_machine.go
@@ -121,5 +121,5 @@ func (r *VirtualMachine) Validate(ctx resources.MultyContext) (errs []validate.V
 }
 
 func (r *VirtualMachine) GetAwsIdentity() string {
-	return fmt.Sprintf("%s-%s-role", r.Args.Name, r.ResourceId)
+	return fmt.Sprintf("%s-vm-role", r.ResourceId)
 }

--- a/test/_configs/network_security_group/network_security_group/main.tf
+++ b/test/_configs/network_security_group/network_security_group/main.tf
@@ -362,13 +362,13 @@ resource "google_compute_subnetwork" "subnet1_gcp" {
   provider                 = "google.europe-west1"
 }
 resource "aws_iam_instance_profile" "vm2_aws" {
-  name     = "test-vm2-vm2_aws-role"
+  name     = "vm2_aws-vm-role"
   role     = aws_iam_role.vm2_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm2_aws" {
   tags               = { "Name" = "test-vm2" }
-  name               = "test-vm2-vm2_aws-role"
+  name               = "vm2_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }
@@ -457,13 +457,13 @@ resource "azurerm_linux_virtual_machine" "vm2_azure" {
   computer_name = "testvm2"
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/subnet/subnet_public_private/main.tf
+++ b/test/_configs/subnet/subnet_public_private/main.tf
@@ -338,13 +338,13 @@ resource "azurerm_subnet_route_table_association" "public_subnet_azure" {
   route_table_id = azurerm_route_table.rt_azure.id
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/vault_access_policy/vault_access_policy/main.tf
+++ b/test/_configs/vault_access_policy/vault_access_policy/main.tf
@@ -156,13 +156,13 @@ resource "google_secret_manager_secret_iam_member" "vault_access_policy_gcp-api_
   provider  = "google.europe-west1"
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/virtual_machine/virtual_machine/main.tf
+++ b/test/_configs/virtual_machine/virtual_machine/main.tf
@@ -98,13 +98,13 @@ resource "google_compute_subnetwork" "subnet_gcp" {
   project                  = "multy-project"
 }
 resource "aws_iam_instance_profile" "vm2_aws" {
-  name     = "test-vm-vm2_aws-role"
+  name     = "vm2_aws-vm-role"
   role     = aws_iam_role.vm2_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm2_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm2_aws-role"
+  name               = "vm2_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }
@@ -177,13 +177,13 @@ resource "azurerm_linux_virtual_machine" "vm2_azure" {
   computer_name = "testvm"
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/virtual_machine/virtual_machine_images/main.tf
+++ b/test/_configs/virtual_machine/virtual_machine_images/main.tf
@@ -95,13 +95,13 @@ resource "google_compute_subnetwork" "subnet_gcp" {
   provider                 = "google.europe-west1"
 }
 resource "aws_iam_instance_profile" "vm2_aws" {
-  name     = "test-vm-vm2_aws-role"
+  name     = "vm2_aws-vm-role"
   role     = aws_iam_role.vm2_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm2_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm2_aws-role"
+  name               = "vm2_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }
@@ -201,13 +201,13 @@ resource "google_compute_instance" "vm2_gcp" {
   provider = "google.europe-west1"
 }
 resource "aws_iam_instance_profile" "vm3_aws" {
-  name     = "test-vm-vm3_aws-role"
+  name     = "vm3_aws-vm-role"
   role     = aws_iam_role.vm3_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm3_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm3_aws-role"
+  name               = "vm3_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }
@@ -280,13 +280,13 @@ resource "azurerm_linux_virtual_machine" "vm3_azure" {
   zone          = "2"
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/virtual_machine/virtual_machine_nic_association/main.tf
+++ b/test/_configs/virtual_machine/virtual_machine_nic_association/main.tf
@@ -94,13 +94,13 @@ resource "azurerm_subnet_route_table_association" "subnet_azure" {
   route_table_id = azurerm_route_table.example_vn_azure.id
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/virtual_machine/virtual_machine_public_ip/main.tf
+++ b/test/_configs/virtual_machine/virtual_machine_public_ip/main.tf
@@ -139,13 +139,13 @@ resource "google_compute_subnetwork" "subnet_gcp" {
   provider                 = "google.europe-west1"
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/_configs/virtual_machine/virtual_machine_size_override/main.tf
+++ b/test/_configs/virtual_machine/virtual_machine_size_override/main.tf
@@ -78,13 +78,13 @@ resource "azurerm_subnet_route_table_association" "subnet_azure" {
   route_table_id = azurerm_route_table.example_vn_azure.id
 }
 resource "aws_iam_instance_profile" "vm2_aws" {
-  name     = "test-vm-vm2_aws-role"
+  name     = "vm2_aws-vm-role"
   role     = aws_iam_role.vm2_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm2_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm2_aws-role"
+  name               = "vm2_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }
@@ -157,13 +157,13 @@ resource "azurerm_linux_virtual_machine" "vm2_azure" {
   zone          = "1"
 }
 resource "aws_iam_instance_profile" "vm_aws" {
-  name     = "test-vm-vm_aws-role"
+  name     = "vm_aws-vm-role"
   role     = aws_iam_role.vm_aws.name
   provider = "aws.eu-west-1"
 }
 resource "aws_iam_role" "vm_aws" {
   tags               = { "Name" = "test-vm" }
-  name               = "test-vm-vm_aws-role"
+  name               = "vm_aws-vm-role"
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }

--- a/test/e2e/virtual_machine_test.go
+++ b/test/e2e/virtual_machine_test.go
@@ -56,7 +56,10 @@ func createSshConfig(t *testing.T, cloud commonpb.CloudProvider) (string, *ssh.C
 		t.Fatalf("unable to create ssh key: %+v", err)
 	}
 
-	//os.WriteFile("key", []byte(privKey), 600)
+	//err = os.WriteFile("key", []byte(privKey), 0600)
+	//if err != nil {
+	//	t.Fatalf("unable to create ssh key: %+v", err)
+	//}
 
 	username := "adminuser"
 	if cloud == commonpb.CloudProvider_AWS {


### PR DESCRIPTION
apparently aws takes forever to apply the policy change

also GetAwsIdentity can't use r.Args.Name because it is called before args are populated