### PR TITLE
test: add test to verify that vault secrets can't be accessed without an access policy

### DIFF
--- a/resources/common/helper.go
+++ b/resources/common/helper.go
@@ -46,18 +46,18 @@ func UniqueId(prefix string, suffix string, formatFunc FormatFunc) string {
 	formattedPrefix := formatFunc(prefix)
 	maxPrefixLen := 20 - len(suffix)
 	if len(formattedPrefix) > maxPrefixLen {
-		result += formattedPrefix[:maxPrefixLen] + generateHash(prefix)
+		result += formattedPrefix[:maxPrefixLen] + GenerateHash(prefix)
 	} else {
 		result += formattedPrefix
 	}
 
 	result += suffix
-	result += generateHash(prefix + suffix)
+	result += GenerateHash(prefix + suffix)
 
 	return result
 }
 
-func generateHash(s string) string {
+func GenerateHash(s string) string {
 	result := ""
 	h := fnv.New32a()
 	_, err := h.Write([]byte(s))

--- a/resources/output/iam/aws_iam_role.go
+++ b/resources/output/iam/aws_iam_role.go
@@ -11,22 +11,28 @@ import (
 
 type AwsIamRole struct {
 	*common.AwsResource `hcl:",squash" default:"name=aws_iam_role"`
-	Name                string                 `hcl:"name"`
-	AssumeRolePolicy    string                 `hcl:"assume_role_policy"`
-	InlinePolicy        AwsIamRoleInlinePolicy `hcl:"inline_policy,optional" hcle:"omitempty"`
+	Name                string `hcl:"name"`
+	AssumeRolePolicy    string `hcl:"assume_role_policy"`
 
 	Id string `json:"id" hcle:"omitempty"`
 }
 
-type AwsIamRoleInlinePolicy struct {
-	Name   string `hcl:"name"`
-	Policy string `hcl:"policy,expr"`
+type AwsIamRolePolicy struct {
+	*common.AwsResource `hcl:",squash" default:"name=aws_iam_policy"`
+	Name                string `hcl:"name"`
+	Policy              string `hcl:"policy,expr"`
 }
 
 type AwsIamRolePolicyAttachment struct {
 	*common.AwsResource `hcl:",squash" default:"name=aws_iam_role_policy_attachment"`
 	Role                string `hcl:"role,expr"`
 	PolicyArn           string `hcl:"policy_arn"`
+}
+
+type AwsIamRolePolicyAttachmentForVap struct {
+	*common.AwsResource `hcl:",squash" default:"name=aws_iam_role_policy_attachment"`
+	Role                string `hcl:"role"`
+	PolicyArn           string `hcl:"policy_arn,expr"`
 }
 
 type AwsIamPolicyStatementPrincipal struct {

--- a/resources/resource_metadata.go
+++ b/resources/resource_metadata.go
@@ -5,6 +5,7 @@ import (
 	"github.com/multycloud/multy/api/errors"
 	"github.com/multycloud/multy/api/proto/commonpb"
 	"github.com/multycloud/multy/api/proto/configpb"
+	"github.com/multycloud/multy/resources/common"
 	"github.com/multycloud/multy/resources/output"
 	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
@@ -173,7 +174,9 @@ func (c *MultyConfig) CreateResource(args proto.Message) (Resource, error) {
 		return nil, err
 	}
 	c.c.ResourceCounter += 1
-	resourceId := fmt.Sprintf("multy_%s_r%d", conv.GetAbbreviatedName(), c.c.ResourceCounter)
+	resourceId := fmt.Sprintf("multy_%s_u%s_r%d", conv.GetAbbreviatedName(),
+		common.GenerateHash(c.c.UserId),
+		c.c.ResourceCounter)
 	r, err := conv.Create(resourceId, args, c.Resources)
 	if err != nil {
 		return nil, err

--- a/resources/types/aws/vault_access_policy.go
+++ b/resources/types/aws/vault_access_policy.go
@@ -1,11 +1,15 @@
 package aws_resources
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/multy-dev/hclencoder"
 	"github.com/multycloud/multy/api/proto/commonpb"
 	"github.com/multycloud/multy/api/proto/resourcespb"
 	"github.com/multycloud/multy/resources"
+	"github.com/multycloud/multy/resources/common"
 	"github.com/multycloud/multy/resources/output"
+	"github.com/multycloud/multy/resources/output/iam"
 	"github.com/multycloud/multy/resources/types"
 )
 
@@ -30,7 +34,40 @@ func (r AwsVaultAccessPolicy) FromState(state *output.TfState) (*resourcespb.Vau
 }
 
 func (r AwsVaultAccessPolicy) Translate(resources.MultyContext) ([]output.TfBlock, error) {
-	return nil, nil
+	var result []output.TfBlock
+	result = append(result, AwsCallerIdentityData{TerraformDataSource: &output.TerraformDataSource{ResourceId: r.ResourceId}})
+
+	policy, err := json.Marshal(iam.AwsIamPolicy{
+		Statement: []iam.AwsIamPolicyStatement{{
+			Action:   []string{"ssm:GetParameter*"},
+			Effect:   "Allow",
+			Resource: fmt.Sprintf("arn:aws:ssm:%s:${data.aws_caller_identity.%s.account_id}:parameter/%s/*", r.Vault.GetCloudSpecificLocation(), r.ResourceId, r.Vault.Args.Name),
+		}, {
+			Action:   []string{"ssm:DescribeParameters"},
+			Effect:   "Allow",
+			Resource: "*",
+		}},
+		Version: "2012-10-17",
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode aws policy: %s", err)
+	}
+
+	result = append(result, &iam.AwsIamRolePolicy{
+		AwsResource: common.NewAwsResource(r.ResourceId, r.ResourceId),
+		Name:        r.ResourceId,
+		// we need to have an expression here because we use template strings within the policy json
+		Policy: fmt.Sprintf("\"%s\"", hclencoder.EscapeString(string(policy))),
+	})
+
+	result = append(result, &iam.AwsIamRolePolicyAttachmentForVap{
+		AwsResource: common.NewAwsResourceWithIdOnly(r.ResourceId),
+		Role:        r.Args.Identity,
+		PolicyArn:   fmt.Sprintf("%s.%s.arn", output.GetResourceName(iam.AwsIamRolePolicy{}), r.ResourceId),
+	})
+
+	return result, nil
 }
 
 func (r AwsVaultAccessPolicy) GetMainResourceName() (string, error) {

--- a/test/_configs/vault_access_policy/vault_access_policy/main.tf
+++ b/test/_configs/vault_access_policy/vault_access_policy/main.tf
@@ -166,6 +166,20 @@ resource "aws_iam_role" "vm_aws" {
   assume_role_policy = "{\"Statement\":[{\"Action\":[\"sts:AssumeRole\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}"
   provider           = "aws.eu-west-1"
 }
+data "aws_caller_identity" "vault_access_policy_aws" {
+  provider = "aws.eu-west-1"
+}
+resource "aws_iam_policy" "vault_access_policy_aws" {
+  tags     = { "Name" = "vault_access_policy_aws" }
+  name     = "vault_access_policy_aws"
+  policy   = "{\"Statement\":[{\"Action\":[\"ssm:GetParameter*\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:ssm:eu-west-1:${data.aws_caller_identity.vault_access_policy_aws.account_id}:parameter/dev-test-secret-multy/*\"},{\"Action\":[\"ssm:DescribeParameters\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}"
+  provider = "aws.eu-west-1"
+}
+resource "aws_iam_role_policy_attachment" "vault_access_policy_aws" {
+  role       = "multy-vm-vm_aws-role"
+  policy_arn = aws_iam_policy.vault_access_policy_aws.arn
+  provider   = "aws.eu-west-1"
+}
 data "aws_ami" "vm_aws" {
   owners      = ["099720109477"]
   most_recent = true


### PR DESCRIPTION
Also fix AWS policy not being removed when the VaultAccessPolicy Multy resource was removed.

When removing the policy, we were removing the underlying inline_policy, but this was ignored by Terraform as documented in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#inline_policy.

Instead I took the policy logic outside the VM code into the VaultAccessPolicy code and used a customer managed policy instead of an inline one.